### PR TITLE
Updated to add `zone=` to the template per the new updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,21 +12,38 @@ CPANM will be installed, along with Perl and `libio-socket-ssl-perl`
 
 ## Role Variables
 
-Each line under `ddclient_conf` will be placed in `/etc/ddclient/ddclient.conf` as-is, except for `name`. I added this distinction in case you had multiple addresses you configured using DDClient.
+Each line under `ddclient_conf` will be placed in `/etc/ddclient/ddclient.conf` as-is. The `name` field will enter the configuration file after a `#` character. I added this distinction in case you had multiple addresses you configured using DDClient.
 
 ```bash
 ddclient_conf:
   - name: DynDNS2
     protocol: dyndns2
     use: web
+    login: login_whatever@domain.com
+    password: password
     server: domains.google.com
   - name: Other
     protocol: other
     ...
 ```
 
+This is an example configuration file:
+
+```bash
+# Ansible managed: Modified on 01/01/2019 by your_ansible_user on your_ansible_machine
+
+# DynDNS2
+protocol=dyndns2
+ssl=yes
+use=web
+login=login_whatever@domain.com
+password=password
+zone=domains.google.com
+```
+
 ## Example Playbook
 
+```yaml
     - hosts: ddclient
       become: true
 
@@ -44,7 +61,7 @@ ddclient_conf:
 
       roles:
          - jpartain89.ddclient
-
+```
 ## License
 
 GPLv2

--- a/templates/ddclient.conf.j2
+++ b/templates/ddclient.conf.j2
@@ -24,6 +24,6 @@ login={{ name.login }}
 password={{ name.password }}
 {% endif -%}
 {% if name.address is defined %}
-{{ name.address }}
+zone={{ name.address }}
 {% endif -%}
 {% endfor %}


### PR DESCRIPTION
Template: Added `zone=` to the url line
README.md:
- Adjusted the explanation for the variables and config file
- Adjusted the original variable example block to add `login` and `password`
- added an example configuration file, showing what the example variables would output
- Added a yaml code block to the playbook example